### PR TITLE
Fix for lein-sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ build environments.
 
 ## Usage
 
-Put `[lein-protoc "0.2.1"]` into the `:plugins` vector of your project.clj.
+Put `[lein-protoc "0.2.2"]` into the `:plugins` vector of your project.clj.
 
 The following options can be configured in the project.clj:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-protoc "0.2.1"
+(defproject lein-protoc "0.2.2"
   :description "Leiningen plugin for compiling Protocol Buffers"
   :url "https://github.com/LiaisonTechnologies/lein-protoc"
   :license {:name "Eclipse Public License"

--- a/src/leiningen/protoc.clj
+++ b/src/leiningen/protoc.clj
@@ -37,6 +37,16 @@
   (str (:target-path project)
        "/generated-sources/protobuf"))
 
+(defn qualify-path
+  [project path]
+  (let [p (Paths/get path (into-array String []))]
+    (if (.isAbsolute p)
+      path
+      (-> (Paths/get (str (:root project) File/separator path)
+                     (into-array String []))
+          .toAbsolutePath
+          .toString))))
+
 (defn print-warn-msg
   [e]
   (leiningen.core.main/warn
@@ -307,7 +317,8 @@
                               (string/join "," errors)))
       (compile-proto!
         (resolve-protoc! (or protoc-version +protoc-version-default+))
-        (or proto-source-paths +proto-source-paths-default+)
+        (mapv (partial qualify-path project)
+              (or proto-source-paths +proto-source-paths-default+))
         (or proto-target-path (target-path-default project))
         (or protoc-timeout +protoc-timeout-default+)
         (resolve-builtin-proto! project)))))


### PR DESCRIPTION
Using the `lein-sub` plugin caused the relative source paths to fail. This PR creates a fully qualified source proto path by pre-pending the `:root` path to any relative source paths.