### PR TITLE
Minor Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ build environments.
 
 ## Usage
 
-Put `[lein-protoc "0.2.2"]` into the `:plugins` vector of your project.clj.
+Put `[lein-protoc "0.3.0"]` into the `:plugins` vector of your project.clj.
 
 The following options can be configured in the project.clj:
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lein-protoc "0.2.2"
+(defproject lein-protoc "0.3.0"
   :description "Leiningen plugin for compiling Protocol Buffers"
   :url "https://github.com/LiaisonTechnologies/lein-protoc"
   :license {:name "Eclipse Public License"


### PR DESCRIPTION
- If Proto-Java is not on classpath it passes nil, which causes a NPE
- If no proto files are found it still proceeded with compilation and
  printed annoying messages. Now will not compile unless source protos
  can be found.