### PR TITLE
Don't pull in the latest version of protoc or grpc by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Put `[lein-protoc "0.4.0"]` into the `:plugins` vector of your project.clj.
 
 The following options can be configured in the project.clj:
 
-- `:protoc-version` the Protocol Buffers Compiler version to use. Defaults to `:latest`
+- `:protoc-version` the Protocol Buffers Compiler version to use. Defaults to `"3.4.1"`.
 - `:proto-source-paths` vector of absolute paths or paths relative to the project root that contain the .proto files to be compiled. Defaults to `["src/proto"]`
 - `:proto-target-path ` the absolute path or path relative to the project root where the sources should be generated. Defaults to `${target-path}/generated-sources/protobuf`
 - `:protoc-grpc` true (or empty map) to generate interfaces for gRPC service definitions with default settings. Defaults to `false`. Can optionally provide a map with the following configs:
-  - `:version` version number for gRPC codegen. Defaults to :latest.
+  - `:version` version number for gRPC codegen. Defaults to `"1.6.6"`.
   - `:target-path` absolute path or path relative to the project root where the sources should be generated. Defaults to the `:proto-target-path`
 - `:protoc-timeout` timeout value in seconds for the compilation process. Defaults to `60`
 

--- a/src/leiningen/protoc.clj
+++ b/src/leiningen/protoc.clj
@@ -24,7 +24,10 @@
            [java.util.concurrent TimeUnit]))
 
 (def +protoc-version-default+
-  :latest)
+  "3.4.0")
+
+(def +protoc-grpc-version-default+
+  "1.6.1")
 
 (def +proto-source-paths-default+
   ["src/proto"])
@@ -343,7 +346,7 @@
    :protoc-grpc-exe
    (when protoc-grpc
      (resolve-protoc-grpc!
-       (or (:version protoc-grpc) +protoc-version-default+)))})
+       (or (:version protoc-grpc) +protoc-grpc-version-default+)))})
 
 (defn all-source-paths
   [{:keys [proto-source-paths] :as project}]
@@ -370,7 +373,6 @@
   project.clj:
 
     :protoc-version     :: the Protocol Buffers Compiler version to use.
-                           Defaults to `:latest`
 
     :proto-source-paths :: vector of absolute paths or paths relative to
                            the project root that contain the .proto files
@@ -384,7 +386,6 @@
                            service definitions with default settings. Can
                            optionally provide a map with the following configs:
                              :version     - version number for gRPC codegen.
-                                            Defaults to :latest.
                              :target-path - absolute path or path relative to
                                             the project root where the sources
                                             should be generated. Defaults to


### PR DESCRIPTION
We had build failures this morning because even though nothing had
changed in our code, lein-protoc pulled in a new and incompatible
version of the grpc compiler.

It should default to pulling in a specific version in order to avoid
this problem; at this time that would be 3.4.1 for protoc and 1.6.6
for grpc. The :latest option still exists, but it is not the default.