### PR TITLE
Add the ability to specify dependencies to include proto files from

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The following options can be configured in the project.clj:
   - `:version` version number for gRPC codegen. Defaults to `"1.6.1"`.
   - `:target-path` absolute path or path relative to the project root where the sources should be generated. Defaults to the `:proto-target-path`
 - `:protoc-timeout` timeout value in seconds for the compilation process. Defaults to `60`
+- `:proto-source-deps` vector of project dependencies to include proto files from. Can optionally include a prefix path with the dependency. Defaults to `[]`. Example `:proto-source-deps [[foo.bar/lib "/resources/proto"] [zip/ping-lib]`.
 
 The plugin hooks to the `javac` task so that sources will be generated prior to java compilation.
 Alternatively, the sources can be generated independently with:


### PR DESCRIPTION
This will allow plugin users to import proto files from other dependencies in their local proto files. We could search all their deps, but this commit allows users to whitelist specific deps. This was mostly a performance concern.

The proto dependency files will not be compiled, but will be included during protoc invocation.

After adding this support, I did a little refactoring to use the same machinery for finding the standard google proto files. There is no advantage to this way, but it keeps us from having to fix bugs in two places. I still left the addition of the builtin protos on their own b/c the error handling is naturally different.